### PR TITLE
Webseer tab list new schedule fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ be logged on GitHub.
 
 ## Changelog
 
+* issue#:15 Fix webseer tab to not show items before schedule is created
+* issue#:15 Fix schedule delete invalid function
+
 * feature: webseer tab functional (webseer plugin update required to use schedule)
 
 --- 1.2 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # maint
 
-The Cacti maint plugin is for the scheduling of maintenace so that Thold /
+The Cacti maint plugin is for the scheduling of maintenance so that Thold /
 Webseer / Other plugins will not alert during that time period.
 
 ## Installation
@@ -21,6 +21,8 @@ Got any ideas or complaints, please see the forums.  If you find a bug, they can
 be logged on GitHub.
 
 ## Changelog
+
+* feature: webseer tab functional (webseer plugin update required to use schedule)
 
 --- 1.2 ---
 

--- a/maint.php
+++ b/maint.php
@@ -416,7 +416,7 @@ function form_actions() {
 
 		form_start('maint.php');
 
-		html_start_box($assoc_actions{get_request_var('drp_action')} . ' ' . __('Device(s)', 'maint'), '60%', '', '3', 'center', '');
+		html_start_box($assoc_actions{get_request_var('drp_action')} . ' ' . __('Webseer(s)', 'maint'), '60%', '', '3', 'center', '');
 
 		if (cacti_sizeof($array)) {
 			if (get_request_var('drp_action') == '1') { /* associate */
@@ -431,7 +431,7 @@ function form_actions() {
 			}elseif (get_request_var('drp_action') == '2') { /* disassociate */
 				print "<tr>
 					<td class='textArea'>
-						<p>" . __('Click \'Continue\' to disassociate the Devices(s) below with the Maintenance Schedule \'<b>%s</b>\'.', $list_name, 'maint') . "</p>
+						<p>" . __('Click \'Continue\' to disassociate the Webseer(s) below from the Maintenance Schedule \'<b>%s</b>\'.', $list_name, 'maint') . "</p>
 						<ul>$list</ul>
 					</td>
 				</tr>\n";
@@ -439,7 +439,7 @@ function form_actions() {
 				$save_html = "<input type='button' value='" . __esc('Cancel', 'maint') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' value='" . __esc('Continue', 'maint') . "' title='" . __esc('Disassociate Maintenance Schedule(s)', 'maint') . "'>";
 			}
 		} else {
-			print "<tr><td><span class='textError'>" . __('You must select at least one Device.', 'maint') . "</span></td></tr>\n";
+			print "<tr><td><span class='textError'>" . __('You must select at least one Webseer.', 'maint') . "</span></td></tr>\n";
 			$save_html = "<input type='button' value='" . __esc('Return', 'maint') . "' onClick='cactiReturnTo()'>";
 		}
 

--- a/maint.php
+++ b/maint.php
@@ -320,7 +320,7 @@ function form_actions() {
 				<input type='hidden' name='save_list' value='1'>
 				<input type='hidden' name='selected_items' value='" . (isset($array) ? serialize($array) : '') . "'>
 				<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
-				<input type='hidden' name='id' value='" . get_request_var_('id') . "'>
+				<input type='hidden' name='id' value='" . get_request_var('id') . "'>
 				$save_html
 			</td>
 		</tr>\n";
@@ -757,6 +757,8 @@ function schedules() {
 function thold_hosts($header_label) {
 	global $assoc_actions, $item_rows;
 
+	$schedule_created = get_request_var('id') ? true : false;
+
     /* ================= input validation and session storage ================= */
 	get_filter_request_var('id');
 
@@ -927,7 +929,7 @@ function thold_hosts($header_label) {
 		$sql_where_params[] = get_request_var('id');
 	}
 
-	if (get_request_var('id')) {
+	if ($schedule_created) {
 		$sql_params = array_merge(array(get_request_var('id')), $sql_where_params);
 		$total_rows = db_fetch_cell_prepared("SELECT
 			COUNT(DISTINCT h.id)
@@ -946,7 +948,7 @@ function thold_hosts($header_label) {
 	$sql_order = get_order_string();
 	$sql_limit = ' LIMIT ' . ($rows*(get_request_var('page')-1)) . ', ' . $rows;
 
-	if (get_request_var('id')) {
+	if ($schedule_created) {
 		$sql_query = "SELECT h.*, pmh.type, graphs, data_sources, tholds,
 			(SELECT schedule FROM plugin_maint_hosts WHERE host=h.id AND schedule=?) AS associated
 			FROM host as h
@@ -1054,7 +1056,15 @@ function thold_hosts($header_label) {
 			form_end_row();
 		}
 	} else {
-		print "<tr><td colspan='8'><em>" . __('No Associated Devices Found', 'maint') . "</em></td></tr>";
+		if ($schedule_created) {
+			if (get_request_var('associated') == 'false') {
+				print "<tr><td colspan='8'><em>" . __('No devices found for selection', 'maint') . "</em></td></tr>";
+			} else {
+				print "<tr><td colspan='8'><em>" . __('No associated devices found for selection.  Uncheck Associated to list unassociated devices.', 'maint') . "</em></td></tr>";
+			}
+		} else {
+			print "<tr><td colspan='8'><em>" . __('Schedule must be created before associating', 'maint') . "</em></td></tr>";
+		}
 	}
 
 	html_end_box(false);
@@ -1078,6 +1088,8 @@ function thold_hosts($header_label) {
  
 function webseer_urls($header_label) {
 	global $assoc_actions, $item_rows;
+
+	$schedule_created = get_request_var('id') ? true : false;
 
     /* ================= input validation and session storage ================= */
     $filters = array(
@@ -1105,10 +1117,6 @@ function webseer_urls($header_label) {
 
 	validate_store_request_vars($filters, 'sess_maint_ws');
 	
-	/* If add, list all */
-	if (!get_request_var('id')) {
-		set_request_var('associated', 'false');
-	}
 	/* ================= input validation ================= */
 
 	/* if the number of rows is -1, set it to the default */
@@ -1208,30 +1216,37 @@ function webseer_urls($header_label) {
 			' (pmh.type IS NOT NULL)';
 	}
 
-	$sql_params = array_merge(array(get_request_var('id')), $sql_where_params);
-	$total_rows = db_fetch_cell_prepared("SELECT
-		COUNT(*)
-		FROM plugin_webseer_urls AS u
-		LEFT JOIN plugin_maint_hosts AS pmh
-			ON ( u.id = pmh.host 
-			AND pmh.type = " . HOST_TYPE_WEBSEER . "
-			AND pmh.schedule = ? )
-		$sql_where",
-		$sql_params);
+	if ($schedule_created) {
+		$sql_params = array_merge(array(get_request_var('id')), $sql_where_params);
+		$total_rows = db_fetch_cell_prepared("SELECT
+			COUNT(*)
+			FROM plugin_webseer_urls AS u
+			LEFT JOIN plugin_maint_hosts AS pmh
+				ON ( u.id = pmh.host 
+				AND pmh.type = " . HOST_TYPE_WEBSEER . "
+				AND pmh.schedule = ? )
+			$sql_where",
+			$sql_params);
+	
+		$sql_params = array_merge(array(get_request_var('id'), get_request_var('id')), $sql_where_params);
+		$sql_query = "SELECT u.*, 
+			(SELECT schedule FROM plugin_maint_hosts WHERE host = u.id AND schedule = ?) AS associated,
+			pmh.type AS maint_type
+			FROM plugin_webseer_urls AS u
+			LEFT JOIN plugin_maint_hosts AS pmh
+				ON ( u.id = pmh.host 
+				AND pmh.type = " . HOST_TYPE_WEBSEER . "
+				AND pmh.schedule = ? )
+			$sql_where
+			LIMIT " . ($rows * (get_request_var('page') - 1)) . ',' . $rows;
 
-	$sql_params = array_merge(array(get_request_var('id'), get_request_var('id')), $sql_where_params);
-	$sql_query = "SELECT u.*, 
-		(SELECT schedule FROM plugin_maint_hosts WHERE host = u.id AND schedule = ?) AS associated,
-		pmh.type AS maint_type
-		FROM plugin_webseer_urls AS u
-		LEFT JOIN plugin_maint_hosts AS pmh
-			ON ( u.id = pmh.host 
-			AND pmh.type = " . HOST_TYPE_WEBSEER . "
-			AND pmh.schedule = ? )
-		$sql_where
-		LIMIT " . ($rows * (get_request_var('page') - 1)) . ',' . $rows;
+		$urls = db_fetch_assoc_prepared($sql_query, $sql_params);
+	} else {
+		/* new schedule, no "id" yet */
+		$total_rows = 0;
+		$urls = array();
+	}
 
-	$urls = db_fetch_assoc_prepared($sql_query, $sql_params);
 
 	$nav = html_nav_bar('notify_lists.php?action=edit&id=' . get_request_var('id'), MAX_DISPLAY_PAGES, get_request_var('page'), $rows, $total_rows, 13, __('Lists', 'maint'), 'page', 'main');
 
@@ -1294,7 +1309,15 @@ function webseer_urls($header_label) {
 			form_end_row();
 		}
 	} else {
-		print "<tr><td><em>" . __('No Associated WebSeer URL\'s Found', 'maint') . "</em></td></tr>";
+		if ($schedule_created) {
+			if (get_request_var('associated') == 'false') {
+				print "<tr><td colspan='8'><em>" . __('No webseer items found for selection', 'maint') . "</em></td></tr>";
+			} else {
+				print "<tr><td colspan='8'><em>" . __('No associated webseer items found for selection.  Uncheck Associated to list unassociated items.', 'maint') . "</em></td></tr>";
+			}
+		} else {
+			print "<tr><td colspan='8'><em>" . __('Schedule must be created before associating', 'maint') . "</em></td></tr>";
+		}
 	}
 	html_end_box(false);
 


### PR DESCRIPTION
Fix schedule delete invalid function.

Do not list items on the Webseer tab before the schedule is created.  I added some text to explain why no items are listed.  Is it clear, or what would help?

Let me know if there is a better way for a new schedule and I will look into it.  Some thoughts are:
1. Change to not show the Devices and Webseer tabs until after the schedule is created (easy).
2. If possible to do, show the rows on the tabs for a new schedule.  When the Associate action is taken, add the schedule before associating.