### PR TITLE
fix picker dateformat

### DIFF
--- a/maint.php
+++ b/maint.php
@@ -667,7 +667,7 @@ function schedule_edit() {
 				showAnim: 'slideDown',
 				numberOfMonths: 1,
 				timeFormat: 'HH:mm',
-				dateFormat: 'MM d, yy, ',
+				dateFormat: 'yy-mm-dd',
 				showButtonPanel: false
 			});
 
@@ -677,7 +677,7 @@ function schedule_edit() {
 				showAnim: 'slideDown',
 				numberOfMonths: 1,
 				timeFormat: 'HH:mm',
-				dateFormat: 'MM d, yy, ',
+				dateFormat: 'yy-mm-dd',
 				showButtonPanel: false
 			});
 		});


### PR DESCRIPTION
@TheWitness you suggested use Cacti date format, but it is little bit problematic - Datepicker uses another format strings (it doesn't know 'Y', ...). So I decided use default 'yy-mm-dd' = the same system as in the other part of cacti.
Fix #23 