### PR TITLE
Keep local hour across daylight saving time change

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ be logged on GitHub.
 
 ## Changelog
 
+* issue: Fix to keep same local hour for standard and daylight saving time
+*   Initial start/end date/time no longer kept, always has next interval
+*   Log calculated next interval
+
 * issue: Fix some PHP 8.1.2 compatibility issues
 
 * issue#15: Fix webseer tab to not show items before schedule is created

--- a/functions.php
+++ b/functions.php
@@ -66,9 +66,9 @@ function plugin_maint_check_schedule($schedule) {
 				/* past, calculate next */
 				if ($sc['etime'] < $t) {
 					/* convert start and end to local so that hour stays same for add days across daylight saving time change */
-					$starttimelocal = (new DateTimeImmutable('@' . strval($sc['stime'])))->setTimezone( new DateTimeZone( date_default_timezone_get()));
-					$endtimelocal   = (new DateTimeImmutable('@' . strval($sc['etime'])))->setTimezone( new DateTimeZone( date_default_timezone_get()));
-					$nowtime        = new DateTimeImmutable();
+					$starttimelocal = (new DateTime('@' . strval($sc['stime'])))->setTimezone( new DateTimeZone( date_default_timezone_get()));
+					$endtimelocal   = (new DateTime('@' . strval($sc['etime'])))->setTimezone( new DateTimeZone( date_default_timezone_get()));
+					$nowtime        = new DateTime();
 					/* add interval days */
 					$addday = new DateInterval( 'P' . strval($sc['minterval'] / 86400) . 'D');
 					while ($endtimelocal < $nowtime) {

--- a/functions.php
+++ b/functions.php
@@ -61,13 +61,35 @@ function plugin_maint_check_schedule($schedule) {
 				if ($t > $sc['stime'] && $t < $sc['etime'])
 					return true;
 				break;
-			case 2:
-				while ($sc['etime'] < $t) {
-					$sc['etime'] += $sc['minterval'];
-					$sc['stime'] += $sc['minterval'];
+
+			case 2: // Recurring
+				/* past, calculate next */
+				if ($sc['etime'] < $t) {
+					/* convert start and end to local so that hour stays same for add days across daylight saving time change */
+					$starttimelocal = (new DateTimeImmutable('@' . strval($sc['stime'])))->setTimezone( new DateTimeZone( date_default_timezone_get()));
+					$endtimelocal   = (new DateTimeImmutable('@' . strval($sc['etime'])))->setTimezone( new DateTimeZone( date_default_timezone_get()));
+					$nowtime        = new DateTimeImmutable();
+					/* add interval days */
+					$addday = new DateInterval( 'P' . strval($sc['minterval'] / 86400) . 'D');
+					while ($endtimelocal < $nowtime) {
+						$starttimelocal = $starttimelocal->add( $addday );
+						$endtimelocal   = $endtimelocal->add( $addday );
+					}
+
+					$sc['stime'] = $starttimelocal->getTimestamp();
+					$sc['etime'] = $endtimelocal->getTimestamp();
+					/* save next interval so not need to recalculate */
+					db_execute_prepared('UPDATE plugin_maint_schedules
+						SET stime = ?, etime = ?
+						WHERE id = ?',
+						array($sc['stime'], $sc['etime'], $schedule));
+					/* format yyyy-mm-dd hh:mm */
+					cacti_log( 'INFO: Maintance schedule "' . $sc['name'] . '" Next start ' . $starttimelocal->format('Y-m-d H:i') .
+					           ' End ' . $endtimelocal->format('Y-m-d H:i'), false, 'MAINT' );
 				}
-				if ($t > $sc['stime'] && $t < $sc['etime'])
+				if ($t > $sc['stime'] && $t < $sc['etime']) {
 					return true;
+				}
 				break;
 		}
 	}


### PR DESCRIPTION
For recurring type, the next schedule time does not keep the same local time hour if the current time offset is a different offset than the initial setup time due to daylight time saving change. This change uses local time to determine the next schedule day.

The schedule entry is updated with the next date/time to always use the current time change policy, to eliminate overhead of calculating it each reference and so can view in the schedule entry. The initial date/time is not retained. For tracking, the schedule date/time update is logged.

To verify the calculation, set a schedule with the date at least 2 days before the previous daylight saving time change. Refresh the list. The schedule will have the next schedule date with the same local hour. The logic does not work for a schedule for only the hour of the time change where the offset increases (daylight saving time to standard time).

Additional changes not included to consider are for the columns in the list to show more detail of the next interval.

Existing
![image](https://github.com/Cacti/plugin_maint/assets/61275958/9c815c13-180b-4649-8629-6e1943d4f816)

Suggested.  MM/DD is fixed format, not based on locale.  Change Interval from Not Defined.
![image](https://github.com/Cacti/plugin_maint/assets/61275958/8a928df7-64fb-464c-9c00-b2cc19b18004)
