### PR TITLE
Change database engine to InnoDB

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -78,7 +78,7 @@ function maint_setup_database() {
 	$data['primary'] = 'id';
 	$data['keys'][] = array('name' => 'mtype', 'columns' => 'mtype');
 	$data['keys'][] = array('name' => 'enabled', 'columns' => 'enabled');
-	$data['type'] = 'MyISAM';
+	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Maintenance Schedules';
 	api_plugin_db_table_create ('maint', 'plugin_maint_schedules', $data);
 
@@ -89,7 +89,7 @@ function maint_setup_database() {
 	$data['primary'] = 'type`,`schedule`,`host';
 	$data['keys'][] = array('name' => 'type', 'columns' => 'type');
 	$data['keys'][] = array('name' => 'schedule', 'columns' => 'schedule');
-	$data['type'] = 'MyISAM';
+	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Maintenance Schedules Hosts';
 	api_plugin_db_table_create ('maint', 'plugin_maint_hosts', $data);
 }


### PR DESCRIPTION
During a server migration and database tuning, I noted for the tables that the database engine was MyISAM and so changed it in my import SQL.  I noticed the base application has conversion to InnoDB (and is supported in the minimum required database server version for the base application).  I wondered if it is preferred and that these should also use it.

This change seems to apply only to a new install.  I wonder about a plugin version change to change existing tables.  I am not familiar with such and so I would only know to copy logic from another plugin (thold).