### PR TITLE
refactor: DRY maint page layout wrapper

### DIFF
--- a/maint.php
+++ b/maint.php
@@ -28,6 +28,7 @@ global $config;
 chdir('../../');
 include_once('./include/auth.php');
 include_once($config['base_path'] . '/plugins/maint/functions.php');
+include_once($config['base_path'] . '/plugins/maint/ui_helpers.php');
 
 define('MAINT_HOST_FILTER_LOC_ANY', '__any'); // internal value unlikely in data
 define('MAINT_HOST_FILTER_LOC_NONE', '__none');
@@ -99,15 +100,11 @@ switch (get_request_var('action')) {
 
 		break;
 	case 'edit':
-		top_header();
-		schedule_edit();
-		bottom_footer();
+		maint_render_with_layout('schedule_edit');
 
 		break;
 	default:
-		top_header();
-		schedules();
-		bottom_footer();
+		maint_render_with_layout('schedules');
 
 		break;
 }

--- a/tests/test_layout_wrapper.php
+++ b/tests/test_layout_wrapper.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | Regression checks for shared layout wrapper routing in maint.php        |
+ |                                                                         |
+ | Run: php tests/test_layout_wrapper.php                                  |
+ +-------------------------------------------------------------------------+
+ */
+
+$pass = 0;
+$fail = 0;
+$events = array();
+
+function assert_true($label, $value) {
+	global $pass, $fail;
+
+	if ($value) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		$fail++;
+	}
+}
+
+function top_header() {
+	global $events;
+	$events[] = 'top_header';
+}
+
+function bottom_footer() {
+	global $events;
+	$events[] = 'bottom_footer';
+}
+
+require_once __DIR__ . '/../ui_helpers.php';
+
+$events = array();
+$callback_runs = 0;
+
+maint_render_with_layout(function () use (&$events, &$callback_runs) {
+	$events[] = 'content';
+	$callback_runs++;
+});
+
+assert_true('layout callback executes once', $callback_runs === 1);
+assert_true('layout call order is top->content->bottom', $events === array('top_header', 'content', 'bottom_footer'));
+
+$source = file_get_contents(__DIR__ . '/../maint.php');
+
+assert_true(
+	'edit action uses shared layout helper',
+	strpos($source, "maint_render_with_layout('schedule_edit');") !== false
+);
+assert_true(
+	'default action uses shared layout helper',
+	strpos($source, "maint_render_with_layout('schedules');") !== false
+);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);

--- a/ui_helpers.php
+++ b/ui_helpers.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
+if (!function_exists('maint_render_with_layout')) {
+	function maint_render_with_layout($renderer) {
+		top_header();
+		call_user_func($renderer);
+		bottom_footer();
+	}
+}


### PR DESCRIPTION
## Summary
- add shared `maint_render_with_layout()` helper for page layout wrappers
- route `edit` and default action rendering in `maint.php` through the helper
- preserve existing behavior while reducing duplicated `top_header()/bottom_footer()` wrapper logic

## Tests
- `php -l maint.php`
- `php -l ui_helpers.php`
- `php -l tests/test_layout_wrapper.php`
- `php tests/test_layout_wrapper.php`

Closes #45
