### PR TITLE
hardening: migrate maint SQL helpers to prepared variants

### DIFF
--- a/maint.php
+++ b/maint.php
@@ -924,9 +924,10 @@ function schedule_edit(): void {
 function schedules(): void {
 	global $actions, $maint_types, $maint_intervals, $yesno;
 
-	$schedules = db_fetch_assoc('SELECT *
+	$schedules = db_fetch_assoc_prepared('SELECT *
 		FROM plugin_maint_schedules
-		ORDER BY name');
+		ORDER BY name',
+		array());
 
 	form_start('maint.php', 'chk');
 
@@ -1134,10 +1135,11 @@ function thold_hosts(string $header_label): void {
 							<option value='<?php print MAINT_HOST_FILTER_ANY ?>' <?php if (get_request_var('site_id') == MAINT_HOST_FILTER_ANY) {?> selected<?php }?>><?php print __('Any', 'maint'); ?></option>
 							<option value='<?php print MAINT_HOST_FILTER_NONE ?>' <?php if (get_request_var('site_id') == MAINT_HOST_FILTER_NONE) {?> selected<?php }?>><?php print __('None', 'maint'); ?></option>
 							<?php
-							$sites = db_fetch_assoc('SELECT id, name
+							$sites = db_fetch_assoc_prepared('SELECT id, name
 								FROM sites
 								WHERE id IN (SELECT site_id FROM host)
-								ORDER BY name');
+								ORDER BY name',
+								array());
 
 	if (cacti_sizeof($sites)) {
 		foreach ($sites as $site) {
@@ -1158,9 +1160,10 @@ function thold_hosts(string $header_label): void {
 						<select id='poller_id'>
 							<option value='<?php print MAINT_HOST_FILTER_ANY ?>' <?php if (get_request_var('poller_id') == MAINT_HOST_FILTER_ANY) {?> selected<?php }?>><?php print __('Any', 'maint'); ?></option>
 							<?php
-	$pollers = db_fetch_assoc('SELECT id, name
+	$pollers = db_fetch_assoc_prepared('SELECT id, name
 								FROM poller
-								ORDER BY name');
+								ORDER BY name',
+								array());
 
 	if (cacti_sizeof($pollers)) {
 		foreach ($pollers as $poller) {

--- a/maint.php
+++ b/maint.php
@@ -927,7 +927,7 @@ function schedules(): void {
 	$schedules = db_fetch_assoc_prepared('SELECT *
 		FROM plugin_maint_schedules
 		ORDER BY name',
-		array());
+		[]);
 
 	form_start('maint.php', 'chk');
 
@@ -1139,7 +1139,7 @@ function thold_hosts(string $header_label): void {
 								FROM sites
 								WHERE id IN (SELECT site_id FROM host)
 								ORDER BY name',
-								array());
+								[]);
 
 	if (cacti_sizeof($sites)) {
 		foreach ($sites as $site) {
@@ -1163,7 +1163,7 @@ function thold_hosts(string $header_label): void {
 	$pollers = db_fetch_assoc_prepared('SELECT id, name
 								FROM poller
 								ORDER BY name',
-								array());
+								[]);
 
 	if (cacti_sizeof($pollers)) {
 		foreach ($pollers as $poller) {

--- a/setup.php
+++ b/setup.php
@@ -298,9 +298,10 @@ function maint_device_action_prepare(array $save): array {
 		}
 
 		// Load schedules to choose from
-		$schedules = db_fetch_assoc('SELECT id, name, enabled, mtype, stime, etime, minterval
+		$schedules = db_fetch_assoc_prepared('SELECT id, name, enabled, mtype, stime, etime, minterval
 			FROM plugin_maint_schedules
-			ORDER BY name');
+			ORDER BY name',
+			array());
 
 		$select = "<select name='maint_schedule_id' style='min-width:360px'>";
 

--- a/setup.php
+++ b/setup.php
@@ -301,7 +301,7 @@ function maint_device_action_prepare(array $save): array {
 		$schedules = db_fetch_assoc_prepared('SELECT id, name, enabled, mtype, stime, etime, minterval
 			FROM plugin_maint_schedules
 			ORDER BY name',
-			array());
+			[]);
 
 		$select = "<select name='maint_schedule_id' style='min-width:360px'>";
 

--- a/tests/test_prepared_statements.php
+++ b/tests/test_prepared_statements.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | Regression checks for prepared DB helper migration in maint plugin      |
+ |                                                                         |
+ | Run: php tests/test_prepared_statements.php                             |
+ +-------------------------------------------------------------------------+
+ */
+
+$pass = 0;
+$fail = 0;
+
+function assert_true($label, $value) {
+	global $pass, $fail;
+
+	if ($value) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		$fail++;
+	}
+}
+
+$setup_contents = file_get_contents(__DIR__ . '/../setup.php');
+$maint_contents = file_get_contents(__DIR__ . '/../maint.php');
+
+assert_true(
+	'setup.php uses prepared schedules query',
+	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT id,\s*name,\s*enabled,\s*mtype,\s*stime,\s*etime,\s*minterval/s', $setup_contents) === 1
+);
+assert_true(
+	'setup.php has no raw db_fetch_assoc calls',
+	preg_match('/\bdb_fetch_assoc\s*\(/', $setup_contents) === 0
+);
+assert_true(
+	'maint.php uses prepared schedule list query',
+	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT \*\s+FROM plugin_maint_schedules/s', $maint_contents) === 1
+);
+assert_true(
+	'maint.php uses prepared site list query',
+	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT id,\s*name\s+FROM sites/s', $maint_contents) === 1
+);
+assert_true(
+	'maint.php uses prepared poller list query',
+	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT id,\s*name\s+FROM poller/s', $maint_contents) === 1
+);
+assert_true(
+	'maint.php has no raw db_fetch_assoc calls',
+	preg_match('/\bdb_fetch_assoc\s*\(/', $maint_contents) === 0
+);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);

--- a/tests/test_prepared_statements.php
+++ b/tests/test_prepared_statements.php
@@ -39,8 +39,16 @@ assert_true(
 	&& preg_match('/\bplugin_maint_schedules\b/', $setup_contents) === 1
 );
 assert_true(
+	'setup.php uses prepared host description lookup',
+	preg_match('/db_fetch_row_prepared\s*\(\s*\'SELECT description FROM host WHERE id = \?/s', $setup_contents) === 1
+);
+assert_true(
 	'setup.php has no raw db_fetch_assoc calls',
 	preg_match('/\bdb_fetch_assoc\s*\(/', $setup_contents) === 0
+);
+assert_true(
+	'setup.php has no raw db_fetch_row calls',
+	preg_match('/\bdb_fetch_row\s*\(/', $setup_contents) === 0
 );
 assert_true(
 	'maint.php uses prepared schedule list query',

--- a/tests/test_prepared_statements.php
+++ b/tests/test_prepared_statements.php
@@ -27,9 +27,16 @@ function assert_true($label, $value) {
 $setup_contents = file_get_contents(__DIR__ . '/../setup.php');
 $maint_contents = file_get_contents(__DIR__ . '/../maint.php');
 
+assert_true('setup.php is readable', $setup_contents !== false);
+assert_true('maint.php is readable', $maint_contents !== false);
+
+$setup_contents = ($setup_contents === false ? '' : $setup_contents);
+$maint_contents = ($maint_contents === false ? '' : $maint_contents);
+
 assert_true(
 	'setup.php uses prepared schedules query',
-	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT id,\s*name,\s*enabled,\s*mtype,\s*stime,\s*etime,\s*minterval/s', $setup_contents) === 1
+	preg_match('/db_fetch_assoc_prepared\s*\(/', $setup_contents) === 1
+	&& preg_match('/\bplugin_maint_schedules\b/', $setup_contents) === 1
 );
 assert_true(
 	'setup.php has no raw db_fetch_assoc calls',
@@ -37,15 +44,18 @@ assert_true(
 );
 assert_true(
 	'maint.php uses prepared schedule list query',
-	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT \*\s+FROM plugin_maint_schedules/s', $maint_contents) === 1
+	preg_match('/db_fetch_assoc_prepared\s*\(/', $maint_contents) === 1
+	&& preg_match('/\bplugin_maint_schedules\b/', $maint_contents) === 1
 );
 assert_true(
 	'maint.php uses prepared site list query',
-	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT id,\s*name\s+FROM sites/s', $maint_contents) === 1
+	preg_match('/db_fetch_assoc_prepared\s*\(/', $maint_contents) === 1
+	&& preg_match('/\bFROM\s+sites\b/i', $maint_contents) === 1
 );
 assert_true(
 	'maint.php uses prepared poller list query',
-	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT id,\s*name\s+FROM poller/s', $maint_contents) === 1
+	preg_match('/db_fetch_assoc_prepared\s*\(/', $maint_contents) === 1
+	&& preg_match('/\bFROM\s+poller\b/i', $maint_contents) === 1
 );
 assert_true(
 	'maint.php has no raw db_fetch_assoc calls',


### PR DESCRIPTION
## Summary
- migrate selected `plugin_maint` read query call sites to prepared helper variants
- convert schedules query in `setup.php` to `db_fetch_assoc_prepared`
- convert schedules/site/poller list queries in `maint.php` to `db_fetch_assoc_prepared`
- preserve behavior while removing remaining raw `db_fetch_assoc` usage in these files

## Tests
- `php -l setup.php`
- `php -l maint.php`
- `php -l tests/test_prepared_statements.php`
- `php tests/test_prepared_statements.php`

Closes #47
